### PR TITLE
fix: change ID column type in TableService for improved data handling

### DIFF
--- a/server/src/rest/services/table.service.ts
+++ b/server/src/rest/services/table.service.ts
@@ -85,7 +85,7 @@ export class TableService {
           // Compact and readable – great for public-facing IDs (e.g., in URLs)
           // Uses gen_random_bytes() for high entropy + custom charset
           table
-            .text('id')
+            .string('id', 16)
             .primary()
             .defaultTo(
               pg.raw(`


### PR DESCRIPTION
- Updated the ID column in TableService from text to string with a length of 16 for better data integrity and consistency in table creation.