### PR TITLE
chore: update version to 0.2.1-beta across all packages

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polarbase-client",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "keywords": [
     "postgresql",
     "backend-as-a-service",

--- a/client/src/environments/environment.development.ts
+++ b/client/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  version: 'v0.2.0-beta',
+  version: 'v0.2.1-beta',
   apiUrl: '/api',
   wsUrl: '/ws',
   dateFormat: 'DD/MM/YYYY',

--- a/client/src/environments/environment.production.ts
+++ b/client/src/environments/environment.production.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  version: 'v0.2.0-beta',
+  version: 'v0.2.1-beta',
   apiUrl: '/api',
   wsUrl: '/ws',
   dateFormat: 'DD/MM/YYYY',

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  version: 'v0.2.0-beta',
+  version: 'v0.2.1-beta',
   apiUrl: '/api',
   wsUrl: '/ws',
   dateFormat: 'DD/MM/YYYY',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polarbase",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "author": "Qui Nguyen",
   "devDependencies": {
     "concurrently": "^8.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polarbase-server",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "keywords": [
     "postgresql",
     "backend-as-a-service",


### PR DESCRIPTION
- Bumped version to 0.2.1-beta in package.json files for server and client.
- Updated environment files to reflect the new version number for development and production settings.