### PR TITLE
feat: enhance AttachmentField with data conversion methods

### DIFF
--- a/client/src/app/shared/field-system/models/attachment/field.object.ts
+++ b/client/src/app/shared/field-system/models/attachment/field.object.ts
@@ -36,4 +36,20 @@ export class AttachmentField extends Field<AttachmentData> {
 
     return errors;
   }
+
+  override convertTextToData(text: string): AttachmentData | null {
+    try {
+      const data = JSON.parse(text);
+      if (Array.isArray(data)) {
+        return data;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  override toString(data?: AttachmentData) {
+    return data ? JSON.stringify(data) : '';
+  }
 }

--- a/client/src/app/shared/spreadsheet/components/field-cell/attachment/cell.component.html
+++ b/client/src/app/shared/spreadsheet/components/field-cell/attachment/cell.component.html
@@ -11,7 +11,7 @@
         (onShow)="onPopoverOpen()"
         (onHide)="onPopoverClose()"
       >
-        @if (data.length < field.maxFiles) {
+        @if (data === undefined || data === null || data.length < field.maxFiles) {
           <file-uploader (onUpload)="onUpload($event)" />
         } @else {
           <p class="text-sm text-surface-500">


### PR DESCRIPTION
- Added `convertTextToData` method to parse JSON strings into AttachmentData arrays, returning null for invalid input.
- Implemented `toString` method to serialize AttachmentData back into JSON format, improving data handling for attachment fields.
- Updated HTML template to safely check the length of data before rendering the file uploader, enhancing robustness.