### PR TITLE
chore: bump version to 0.4.2-beta across all relevant files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
     },
     "client": {
       "name": "polarbase-client",
-      "version": "0.4.1-beta",
+      "version": "0.4.2-beta",
       "dependencies": {
         "@angular/common": "^20.3.0",
         "@angular/compiler": "^20.3.0",
@@ -53,7 +53,7 @@
     },
     "server": {
       "name": "polarbase-server",
-      "version": "0.4.1-beta",
+      "version": "0.4.2-beta",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.53",
         "@ai-sdk/google": "^2.0.44",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polarbase-client",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "keywords": [
     "postgresql",
     "backend-as-a-service",

--- a/client/src/environments/environment.development.ts
+++ b/client/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  version: 'v0.4.1-beta',
+  version: 'v0.4.2-beta',
   assetUrl: '/static',
   apiUrl: '/api',
   wsUrl: '/ws',

--- a/client/src/environments/environment.production.ts
+++ b/client/src/environments/environment.production.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  version: 'v0.4.1-beta',
+  version: 'v0.4.2-beta',
   assetUrl: '/static',
   apiUrl: '/api',
   wsUrl: '/ws',

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  version: 'v0.4.1-beta',
+  version: 'v0.4.2-beta',
   assetUrl: '/static',
   apiUrl: '/api',
   wsUrl: '/ws',

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       # Core
       - NODE_ENV=production
       - NAME=PolarBase
-      - VERSION=v0.4.1-beta
+      - VERSION=v0.4.2-beta
       - HOSTNAME=0.0.0.0
       - PORT=3000
       - VERBOSE=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polarbase",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "author": "Qui Nguyen",
   "devDependencies": {
     "concurrently": "^8.0.0"

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,7 +1,7 @@
 # Core Application
 NODE_ENV=development
 NAME=PolarBase
-VERSION=v0.4.1-beta
+VERSION=v0.4.2-beta
 HOSTNAME=0.0.0.0
 PORT=3000
 VERBOSE=false

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polarbase-server",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "keywords": [
     "postgresql",
     "backend-as-a-service",


### PR DESCRIPTION
- Updated version from 0.4.1-beta to 0.4.2-beta in package.json, bun.lock, docker-compose.yaml, client and server environment files, and server/.env.example.
- Ensured consistency in versioning across client and server configurations.